### PR TITLE
Added license to app

### DIFF
--- a/R/app.R
+++ b/R/app.R
@@ -136,15 +136,24 @@ handwriterApp <- function(...){
                                                                          closedUI('closed1'),
                                                                        ),
                                                                        
-                                                                       shiny::tabPanel( 
-                                                                         "About",
-                                                                         shiny::includeHTML(system.file(file.path("extdata", "HTML"), "about.HTML", package = "handwriterApp"))
-                                                                       ),
-                                                                       
-                                                                       shiny::tabPanel(
-                                                                         "Contact",
-                                                                         shiny::includeHTML(system.file(file.path("extdata", "HTML"), "contact.HTML", package = "handwriterApp"))
+                                                                       shiny::navbarMenu("More",
+                                                                                         shiny::tabPanel( 
+                                                                                           "About",
+                                                                                           shiny::includeHTML(system.file(file.path("extdata", "HTML"), "about.HTML", package = "handwriterApp"))
+                                                                                         ),
+                                                                                         
+                                                                                         shiny::tabPanel(
+                                                                                           "Contact",
+                                                                                           shiny::includeHTML(system.file(file.path("extdata", "HTML"), "contact.HTML", package = "handwriterApp"))
+                                                                                         ),
+                                                                                         
+                                                                                         shiny::tabPanel(
+                                                                                           "License",
+                                                                                           shiny::includeHTML(system.file(file.path("extdata", "HTML"), "license.HTML", package = "handwriterApp"))
+                                                                                         )
                                                                        )
+                                                                       
+                                                                       
                                                      ))),
                      # footer
                      shiny::tags$div(id="global-footer",

--- a/inst/extdata/HTML/LICENSE.html
+++ b/inst/extdata/HTML/LICENSE.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<body>
+  <div id="indent">
+    <h1>LICENSE</h1>
+    <p> Handwriter performs writership analysis of handwritten documents. Copyright (C) 2021 Iowa
+    State University of Science and Technology on behalf of its Center for Statistics and
+    Applications in Forensic Evidence.
+    
+    This program is free software: you can redistribute it and/or modify it under the terms of the
+    GNU General Public License as published by the Free Software Foundation, either version 3 of
+    the License, or (at your option) any later version.
+    
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+    without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+    See the <a href='https://www.gnu.org/licenses/' target='_blank'>GNU General Public License</a> for more details.
+    </p>
+  </div>
+   <br>
+</body>


### PR DESCRIPTION
Including the license as an md file created problems because then the markdown package has to be added to imports, but a note is returned on R CMD check that markdown isn't called anywhere.

Including the license as an html file with includeHTML caused a warning that the html file was a complete html file. Also, the first few lines of the file don't display correctly.

As a temporary work-around, I added a new html snippet that includes a link to the license: https://www.gnu.org/licenses/